### PR TITLE
Map underscore to hyphen for PermissionType

### DIFF
--- a/lib/aker-study-client.rb
+++ b/lib/aker-study-client.rb
@@ -27,5 +27,8 @@ module StudyClient
   end
 
   class Permission < Base
+    def permission_type
+      attributes['permission-type']
+    end
   end
 end


### PR DESCRIPTION
This is needed to fix an error that arose after implementing JWT in the Work Orders app, which would prevent creating a work order after selecting a project